### PR TITLE
Replace print with loguru

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,9 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+# Package version
+_version.py
+
 # VSCode
 .vscode/
 

--- a/examples/example_01.ipynb
+++ b/examples/example_01.ipynb
@@ -6,6 +6,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from pathlib import Path\n",
+    "\n",
     "from topofileformats.asd import load_asd, create_animation"
    ]
   },
@@ -15,7 +17,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "FILE = \"../tests/resources/sample_0.asd\"\n",
+    "FILE = Path(\"../tests/resources/sample_0.asd\")\n",
     "frames, pixel_to_nm_scaling, metadata = load_asd(file_path=FILE, channel=\"TP\")"
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
 ]
-dependencies = ["numpy", "loguru"]
+
 keywords = [
   "afm",
   "image processing"
@@ -26,7 +26,8 @@ keywords = [
 
 dependencies = [
   "matplotlib",
-  "numpy"
+  "numpy",
+  "loguru",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
 ]
-dependencies = ["numpy"]
+dependencies = ["numpy", "loguru"]
 
 [project.optional-dependencies]
 dev = ["pytest", "black", "pylint"]

--- a/tests/test_asd.py
+++ b/tests/test_asd.py
@@ -30,9 +30,7 @@ RESOURCES = BASE_DIR / "tests" / "resources"
         ),
     ],
 )
-def test_load_asd(
-    file_name: str, channel: str, number_of_frames: int, pixel_to_nm_scaling: float
-) -> None:
+def test_load_asd(file_name: str, channel: str, number_of_frames: int, pixel_to_nm_scaling: float) -> None:
     """Test the normal operation of loading a .asd file."""
 
     result_frames = list

--- a/topofileformats/__init__.py
+++ b/topofileformats/__init__.py
@@ -1,1 +1,6 @@
-"""topofileformats."""
+"""A module for loading AFM files of different formats."""
+
+
+from loguru import logger
+
+logger.disable(__package__)

--- a/topofileformats/asd.py
+++ b/topofileformats/asd.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 from pathlib import Path
-import sys
+
 from typing import BinaryIO
 
-from loguru import logger
+
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib import animation
 
+
+from topofileformats.logging import logger
 from topofileformats.io import (
     read_int32,
     read_int16,
@@ -23,9 +25,6 @@ from topofileformats.io import (
     read_double,
     skip_bytes,
 )
-
-logger.remove()
-logger.add(sys.stderr, format="<white>{time}</white> | <level>{level}</level> | <blue>{message}</blue>")
 
 
 # pylint: disable=too-few-public-methods
@@ -144,12 +143,12 @@ def calculate_scaling_factor(
     raise ValueError(f"channel {channel} not known for .asd file type.")
 
 
-def load_asd(file_path: Path | str, channel: str):
+def load_asd(file_path: Path, channel: str):
     """Load a .asd file.
 
     Parameters
     ----------
-    file_path: Union[Path, str]
+    file_path: Path
         Path to the .asd file.
     channel: str
         Channel to load. Note that only three channels seem to be present in a single .asd file. Options: TP

--- a/topofileformats/asd.py
+++ b/topofileformats/asd.py
@@ -192,7 +192,7 @@ know how to decode this file version."
         pixel_to_nanometre_scaling_factor_y = header_dict["y_nm"] / header_dict["y_pixels"]
         if pixel_to_nanometre_scaling_factor_x != pixel_to_nanometre_scaling_factor_y:
             logger.warning(
-                f"WARNING: Resolution of image is different in x and y directions:\
+                f"Resolution of image is different in x and y directions:\
 x: {pixel_to_nanometre_scaling_factor_x}\
  y: {pixel_to_nanometre_scaling_factor_y}"
             )

--- a/topofileformats/asd.py
+++ b/topofileformats/asd.py
@@ -1,8 +1,9 @@
 """For decoding and loading .asd AFM file format into Python Numpy arrays."""
 
+from __future__ import annotations
 from pathlib import Path
 import sys
-from typing import BinaryIO, Union
+from typing import BinaryIO
 
 from loguru import logger
 import numpy as np
@@ -168,7 +169,9 @@ def load_asd(file_path: Path | str, channel: str):
     version please either look into the `read_header_file_version_x` functions or print the keys too see what metadata
     is available.
     """
-    with Path.open(file_path, "rb", encoding="UTF-8") as open_file:
+    # Binary mode open does not take an encoding argument
+    # pylint: disable=unspecified-encoding
+    with Path.open(file_path, "rb") as open_file:
         file_version = read_file_version(open_file)
 
         if file_version == 0:

--- a/topofileformats/asd.py
+++ b/topofileformats/asd.py
@@ -42,8 +42,8 @@ class VoltageLevelConverter:
         self.scaling_factor = scaling_factor
         self.resolution = resolution
         logger.info(
-            f"created voltage converter. ad_range: {analogue_digital_range} -> {self.ad_range}, \
-max voltage: {max_voltage}, scaling factor: {scaling_factor}, resolution: {resolution}"
+            f"created voltage converter. ad_range: {analogue_digital_range} -> {self.ad_range}, "
+            f"max voltage: {max_voltage}, scaling factor: {scaling_factor}, resolution: {resolution}"
         )
 
 
@@ -123,20 +123,20 @@ def calculate_scaling_factor(
     """
     if channel == "TP":
         logger.info(
-            f"Scaling factor: Type: {channel} -> TP | piezo extension {z_piezo_gain} \
-* piezo gain {z_piezo_extension} = scaling factor {z_piezo_gain * z_piezo_extension}"
+            f"Scaling factor: Type: {channel} -> TP | piezo extension {z_piezo_gain} "
+            f"* piezo gain {z_piezo_extension} = scaling factor {z_piezo_gain * z_piezo_extension}"
         )
         return z_piezo_gain * z_piezo_extension
     if channel == "ER":
         logger.info(
-            f"Scaling factor: Type: {channel} -> ER | - scanner sensitivity {-scanner_sensitivity} \
-= scaling factor {-scanner_sensitivity}"
+            f"Scaling factor: Type: {channel} -> ER | - scanner sensitivity {-scanner_sensitivity} "
+            f"= scaling factor {-scanner_sensitivity}"
         )
         return -scanner_sensitivity
     if channel == "PH":
         logger.info(
-            f"Scaling factor: Type: {channel} -> PH | - phase sensitivity {-phase_sensitivity} \
-= scaling factor {-phase_sensitivity}"
+            f"Scaling factor: Type: {channel} -> PH | - phase sensitivity {-phase_sensitivity} "
+            f"= scaling factor {-phase_sensitivity}"
         )
         return -phase_sensitivity
 
@@ -183,8 +183,8 @@ def load_asd(file_path: Path, channel: str):
             header_dict = read_header_file_version_2(open_file)
         else:
             raise ValueError(
-                f"File version {file_version} unknown. Please add support if you\
-know how to decode this file version."
+                f"File version {file_version} unknown. Please add support if you "
+                "know how to decode this file version."
             )
         logger.info(f"header dict: \n{header_dict}")
 
@@ -192,22 +192,16 @@ know how to decode this file version."
         pixel_to_nanometre_scaling_factor_y = header_dict["y_nm"] / header_dict["y_pixels"]
         if pixel_to_nanometre_scaling_factor_x != pixel_to_nanometre_scaling_factor_y:
             logger.warning(
-                f"Resolution of image is different in x and y directions:\
-x: {pixel_to_nanometre_scaling_factor_x}\
- y: {pixel_to_nanometre_scaling_factor_y}"
+                f"Resolution of image is different in x and y directions:"
+                f"x: {pixel_to_nanometre_scaling_factor_x}"
+                f"y: {pixel_to_nanometre_scaling_factor_y}"
             )
         pixel_to_nanometre_scaling_factor = pixel_to_nanometre_scaling_factor_x
 
         if channel == header_dict["channel1"]:
-            logger.info(
-                f"Requested channel {channel} matches first channel in file: \
-{header_dict['channel1']}"
-            )
+            logger.info(f"Requested channel {channel} matches first channel in file: " f"{header_dict['channel1']}")
         elif channel == header_dict["channel2"]:
-            logger.info(
-                f"Requested channel {channel} matches second channel in file: \
-{header_dict['channel2']}"
-            )
+            logger.info(f"Requested channel {channel} matches second channel in file: " f"{header_dict['channel2']}")
 
             # Skip first channel data
             _size_of_frame_header = header_dict["frame_header_length"]
@@ -219,8 +213,8 @@ x: {pixel_to_nanometre_scaling_factor_x}\
             _ = open_file.read(length_of_all_first_channel_frames)
         else:
             raise ValueError(
-                f"Channel {channel} not found in this file's available channels: \
-{header_dict['channel1']}, {header_dict['channel2']}"
+                f"Channel {channel} not found in this file's available channels: "
+                f"{header_dict['channel1']}, {header_dict['channel2']}"
             )
 
         scaling_factor = calculate_scaling_factor(
@@ -756,8 +750,7 @@ def create_analogue_digital_converter(analogue_digital_range, scaling_factor, re
         )
     else:
         raise ValueError(
-            f"Analogue to digital range hex value {analogue_digital_range} has no known \
-analogue-digital mapping."
+            f"Analogue to digital range hex value {analogue_digital_range} has no known " "analogue-digital mapping."
         )
     logger.info(f"Analogue to digital mapping | Range: {analogue_digital_range} -> {mapping}")
     logger.info(f"Converter: {converter}")

--- a/topofileformats/asd.py
+++ b/topofileformats/asd.py
@@ -186,7 +186,7 @@ def load_asd(file_path: Path, channel: str):
                 f"File version {file_version} unknown. Please add support if you "
                 "know how to decode this file version."
             )
-        logger.info(f"header dict: \n{header_dict}")
+        logger.debug(f"header dict: \n{header_dict}")
 
         pixel_to_nanometre_scaling_factor_x = header_dict["x_nm"] / header_dict["x_pixels"]
         pixel_to_nanometre_scaling_factor_y = header_dict["y_nm"] / header_dict["y_pixels"]

--- a/topofileformats/asd.py
+++ b/topofileformats/asd.py
@@ -199,7 +199,7 @@ def load_asd(file_path: Path, channel: str):
         pixel_to_nanometre_scaling_factor = pixel_to_nanometre_scaling_factor_x
 
         if channel == header_dict["channel1"]:
-            logger.info(f"Requested channel {channel} matches first channel in file: " f"{header_dict['channel1']}")
+            logger.info(f"Requested channel {channel} matches first channel in file: {header_dict['channel1']}")
         elif channel == header_dict["channel2"]:
             logger.info(f"Requested channel {channel} matches second channel in file: " f"{header_dict['channel2']}")
 

--- a/topofileformats/asd.py
+++ b/topofileformats/asd.py
@@ -168,11 +168,9 @@ def load_asd(file_path: Path, channel: str):
     version please either look into the `read_header_file_version_x` functions or print the keys too see what metadata
     is available.
     """
-
     # Binary mode open does not take an encoding argument
     # pylint: disable=unspecified-encoding
     with Path.open(file_path, "rb") as open_file:
-
         file_version = read_file_version(open_file)
 
         if file_version == 0:

--- a/topofileformats/asd.py
+++ b/topofileformats/asd.py
@@ -26,6 +26,8 @@ from topofileformats.io import (
     skip_bytes,
 )
 
+logger.enable(__package__)
+
 
 # pylint: disable=too-few-public-methods
 class VoltageLevelConverter:

--- a/topofileformats/logging.py
+++ b/topofileformats/logging.py
@@ -9,6 +9,7 @@ logger.remove()
 logger.add(
     sys.stderr,
     colorize=True,
-    format="<blue>{time:HH:mm:ss}</blue> | <green>{file}</green>:<green>{module}</green>:<green>"
-    "{function}</green>:<green>{line}</green> | <level>{message}</level>",
+    format="<blue>{time:HH:mm:ss}</blue> | <level>{level}</level> |"
+    "<magenta>{file}</magenta>:<magenta>{module}</magenta>:<magenta>"
+    "{function}</magenta>:<magenta>{line}</magenta> | <level>{message}</level>",
 )

--- a/topofileformats/logging.py
+++ b/topofileformats/logging.py
@@ -1,0 +1,14 @@
+"""Configure logging."""
+
+import sys
+
+from loguru import logger
+
+logger.remove()
+# Set the format to have blue time, green file, module, function and line, and white message
+logger.add(
+    sys.stderr,
+    colorize=True,
+    format="<blue>{time:HH:mm:ss}</blue> | <green>{file}</green>:<green>{module}</green>:<green>"
+    "{function}</green>:<green>{line}</green> | <level>{message}</level>",
+)


### PR DESCRIPTION
Closes #2 

This PR replaces all the `print` statements with logging from `loguru` (colour coded too)

<img width="851" alt="image" src="https://github.com/AFM-SPM/topofileformats/assets/86117496/d0ee8427-a7d8-4f68-9e11-0f24ba1265ca">
