### PR TITLE
Adds code of conduct for contributing; expands README.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,103 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for
+everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity
+and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion,
+or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take
+appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits,
+issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for
+moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing
+the community in public spaces.  Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible
+for enforcement: [Alice Pyne](mailto:a.l.pyne@sheffield.ac.uk) or [Bob Turner](mailto:r.d.turner@sheffield.ac.uk).  All
+complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem
+in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the
+community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation
+and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including
+unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding
+interactions in community spaces as well as external channels like social media. Violating these terms may lead to a
+temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified
+period of time. No public or private interaction with the people involved, including unsolicited interaction with those
+enforcing the Code of Conduct, is allowed during this period.  Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate
+behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant version
+2.0](https://www.contributor-covenant.org/version/2/0/code_of_conduct.html).
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement
+ladder](https://github.com/mozilla/diversity).
+
+[Contributor Covenant](https://www.contributor-covenant.org)
+
+For answers to common questions about this code of conduct, see the
+[FAQ](https://www.contributor-covenant.org/faq). [Translations](https://www.contributor-covenant.org/translations) are
+available.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,46 @@
 # topofileformats
 
-A library for loading various AFM file formats.
+<div align="center">
 
-File format support: `.asd`
+[![PyPI version](https://badge.fury.io/py/topofileformats.svg)](https://badge.fury.io/py/topofileformats)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/topofileformats)
+[![Code style: Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json))](https://github.com/astral-sh/ruff)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Code style: flake8](https://img.shields.io/badge/code%20style-flake8-456789.svg)](https://github.com/psf/flake8)
+<!-- [![codecov](https://codecov.io/gh/AFM-SPM/topofileformats/branch/dev/graph/badge.svg)]
+(https://codecov.io/gh/AFM-SPM/topofileformats) -->
+[![pre-commit.ci
+status](https://results.pre-commit.ci/badge/github/AFM-SPM/topofileformats/main.svg)](https://results.pre-commit.ci/latest/github/AFM-SPM/topofileformats/main)
+
+</div>
+
+A library for loading various Atomic Force Microscopy (AFM) file formats into Python. This library is primarily intended
+for use with [TopoStats](https://github.com/AFM-SPM/TopoStats).
+
+Supported file formats
+
+| File format | Description    |
+|-------------|----------------|
+| `.asd`      | High-speed AFM |
+
+Support for the following additional formats is planned. Some of these are already supported in TopoStats and are
+awaiting refactoring to move their functionality into topofileformats these are denoted in bold below.
+
+| File format | Description                                             | Status                                     |
+|-------------|---------------------------------------------------------|--------------------------------------------|
+| `.spm`      | [Bruker](https://www.bruker.com/)                       | TopoStats supported, to be migrated (#16). |
+| `.ibw`      | [WaveMetrics](https://www.wavemetrics.com/)             | TopoStats supported, to be migrated (#17). |
+| `.gwy`      | [Gwyddion](http://gwyddion.net/)                        | TopoStats supported, to be migrated (#1).  |
+| `.nhf`      | [Nanosurf](https://www.nanosurf.com/en/)                | To Be Implemented.                         |
+| `.aris`     | [Imaris Oxford Instruments](https://imaris.oxinst.com/) | To Be Implemented.                         |
+| `.tiff`     | [Park Systems](https://www.parksystems.com/)            | To Be Implemented.                         |
 
 ## Usage
 
-## .asd
+If you wish to process AFM images supported by `topofileformats` it is recommend you use
+[TopoStats](https://github.com/AFM-SPM/TopoStats) to do so, however the library can be used on its own.
+
+### .asd
 
 You can open `.asd` files using the `load_asd` function. Just pass in the path to the file and the channel name that you
 want to use. (If in doubt use the `"TP"` topography channel).
@@ -21,3 +55,36 @@ from topofileformats import load_asd
 
 frames, pixel_to_nanometre_scaling_factor, metadata = load_asd(file_path="./my_asd_file.asd")
 ```
+
+## Contributing
+
+Bug reports and feature requests are welcome. Please search for existing issues, if none relating to your bug/feature
+are found then feel free to create a new [issue](https://github.com/AFM-SPM/topofileformats/issues/new) detailing what
+went wrong or the feature you would like to see implemented.
+
+Pull requests are also welcome, please note that we have a [Code of
+Conduct](https://github.com/AFM-SPM/topofileformats/blob/main/CODE_OF_CONDUCT.md).
+
+### Setup
+
+We use [pre-commit](https://pre-commit.com) to apply linting via [ruff](https://github.com/astral-sh/ruff) and
+[pylint](https://pylint.pycqa.org/en/latest/index.html) pre-commit hooks and use the
+[Black](https://github.com/psf/black) and [Flake8](https://github.com/psf/flake8) code styles. To set yourself up for
+contributing after cloning the package and creating a Python virtual environment you should install the development
+dependencies and `pre-commit` as shown below.
+
+``` bash
+# Activate your virtual environment, this will depend on which system you use e.g. conda or virtualenvwrapper
+# Clone the repository
+git clone git@github.com:AFM-SPM/topofileformats.git
+# Change directories into the newly cloned directory
+cd topofileformats
+# Install the package along with the optional development (dev) dependencies
+pip install -e .[dev]
+# Install pre-commit
+pre-commit install
+```
+
+This will ensure that any commits and pull requests you make will pass the [Pre-commit Continuous
+Integration](https://pre-commit.ci). Where possible `ruff` will correct the changes it can, but it may require you to
+address some issues manually, before adding any changes and attempting to commit again.

--- a/topofileformats/asd.py
+++ b/topofileformats/asd.py
@@ -163,7 +163,7 @@ def load_asd(file_path: Path | str, channel: str):
     version please either look into the `read_header_file_version_x` functions or print the keys too see what metadata
     is available.
     """
-    with Path.open(file_path, "rb", encoding="UTF-8") as open_file:
+    with Path.open(file_path, "rb", encoding=None) as open_file:  # pylint: disable=W1514
         file_version = read_file_version(open_file)
 
         if file_version == 0:

--- a/topofileformats/asd.py
+++ b/topofileformats/asd.py
@@ -1,5 +1,5 @@
 """For decoding and loading .asd AFM file format into Python Numpy arrays."""
-
+from __future__ import annotations
 from pathlib import Path
 from typing import BinaryIO
 


### PR DESCRIPTION
Closes #14

+ Adds `CODE_OF_CONDUCT.md`.
+ Adds supported file formats and intended work to `README.md`.
+ Adds basic instructions on contributing to `README.md`.