### PR TITLE
Adds ids to tests via pytest.param

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![PyPI version](https://badge.fury.io/py/topofileformats.svg)](https://badge.fury.io/py/topofileformats)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/topofileformats)
-[![Code style: Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json))](https://github.com/astral-sh/ruff)
+[![Code style: Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Code style: flake8](https://img.shields.io/badge/code%20style-flake8-456789.svg)](https://github.com/psf/flake8)
 <!-- [![codecov](https://codecov.io/gh/AFM-SPM/topofileformats/branch/dev/graph/badge.svg)]

--- a/tests/test_asd.py
+++ b/tests/test_asd.py
@@ -11,20 +11,8 @@ RESOURCES = BASE_DIR / "tests" / "resources"
 @pytest.mark.parametrize(
     ("file_name", "channel", "number_of_frames", "pixel_to_nm_scaling"),
     [
-        # File type 0
-        (
-            "sample_0.asd",
-            "TP",
-            142,
-            0.78125,
-        ),
-        # File type 1
-        (
-            "sample_1.asd",
-            "TP",
-            197,
-            2.0,
-        ),
+        pytest.param("sample_0.asd", "TP", 142, 0.78125, id="file type 0"),
+        pytest.param("sample_1.asd", "TP", 197, 2.0, id="file type 1"),
     ],
 )
 def test_load_asd(file_name: str, channel: str, number_of_frames: int, pixel_to_nm_scaling: float) -> None:


### PR DESCRIPTION
I discovered [`pytest.param()`](https://docs.pytest.org/en/7.1.x/reference/reference.html?#pytest.param) which allows parameter sets to be given `ids` and thought it a simple but useful habit to start using.

Another useful option is the `marks=` so particular parameters can be marked to fail, or be skipped if certain conditions are met, but these aren't needed here.