### PR TITLE
Configuring test coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,3 +131,11 @@ convention = "numpy"
 
 [tool.ruff.flake8-pytest-style]
 fixture-parentheses = true
+
+[tool.coverage.run]
+source = ["topofileformats"]
+omit = [
+  "topofileformats/_version.py",
+  "*tests*",
+  "**/__init__*",
+]


### PR DESCRIPTION
Noticed that we hadn't configured test coverage to exclude the `tests/` directory so have added this to `pyproject.toml`.